### PR TITLE
Refactor/scripts

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -42,6 +42,8 @@
             <label for="sides"><div class="grow"><img src="../assets/avo-dip-small.png" class="img-icon grow"></div><br>Sides</label>
           </div>
         </form>
+        <div class="all-recipes-container flex-row">
+        </div>
         <div class="recipes-container flex-row">
         </div>
         <div class="pantry-container flex-row">

--- a/src/index.html
+++ b/src/index.html
@@ -44,9 +44,11 @@
         </form>
         <div class="all-recipes-container flex-row">
         </div>
-        <div class="recipes-container flex-row">
+        <div class="favorites-container flex-row">
         </div>
         <div class="pantry-container flex-row">
+        </div>
+        <div class="whats-cookin-container flex-row">
         </div>
         <div class="flex-column whats-cookin-container hidden">
           <div class="whats-cookin-img">

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -1,6 +1,7 @@
 // querySelectors
 let modal;
-const recipeCardContainer = document.querySelector('.recipes-container');
+const favoritesContainer = document.querySelector('.favorites-container');
+const whatsCookinContainer = document.querySelector('.whats-cookin-container');
 const myFavoritesNav = document.querySelector('#my-favorites-nav');
 const allRecipesNav = document.querySelector('#all-recipes-nav');
 const myPantryNav = document.querySelector('#my-pantry-nav');
@@ -27,58 +28,54 @@ allRecipesContainer.addEventListener('click', () => {
   determineClickOnAllRecipes(event);
 });
 
-recipeCardContainer.addEventListener('click', () => {
-  determineClick(event);
+favoritesContainer.addEventListener('click', () => {
+  determineClickInFavorites(event);
 });
-// ON HOMESCREEN
-//when heart is clicked
-// need to be able to mark as favorite/ unmark as favorite
-  // need eventlisteners for heart icons (through event bubbling)
-  // this should change boolean value, change heart icon (change heart icon)
 
-  //when plus is clicked
-  // need to be able to mark as readyToCook / unmark as readyToCook
-   // need eventlisteners for plus (through event bubbling)
-   // this should change boolean value of readyToCook, change plus icon
-// ----------------------
-// when favorites page is clicked on,
-  // parse all recipes,
-    // if isFavorites is true,
-      // create recipe card and display
-      // need eventlisteners for plus (through event bubbling)
-  // when heart is deselected,
-     // boolean value needs to change, toggle heart graphic, and splice html.
+whatsCookinContainer.addEventListener('click', () => {
+  determineClickInWhatsCookin(event);
+});
 
-//WHATS COOKIN
-//when what's Cookin page is clicked on,
-  // parse all recipes
-      // if what's cookin is true
-      // create recipe card and display
-      // need eventlisteners for plus (through event bubbling)
-// when plus icon is deselected (aka minus is clicked),
-  // boolean value needs to change, toggle plus graphic, and splice html.
-
-// function determineClick(event) {
-//   addRemoveFavorites(event);
-//   addToWhatsCookin(event);
-//   openModel(event);
-// }
 function determineClickOnAllRecipes(event) {
   markUnmarkAsFavorite(event);
   markUnmarkReadyToCook(event);
+  openModal(event);
 }
 
-function determineClick(event) {
-  markUnmarkAsFavorite(event);
+function determineClickInFavorites(event) {
+  recipeBox.allRecipes.forEach(recipe => {
+    if (event.target.id === `favorite-btn-${recipe.id}`) {
+      markUnmarkAsFavorite(event);
+      removeRecipeCard(event);
+    }
+  })
   markUnmarkReadyToCook(event);
-  removeRecipeCard(event);
-  openModel(event);
+  openModal(event);
 }
+
+function determineClickInWhatsCookin(event) {
+  recipeBox.allRecipes.forEach(recipe => {
+    if (event.target.id === `whats-cookin-btn-${recipe.id}`) {
+      markUnmarkReadyToCook(event);
+      removeRecipeCard(event);
+    }
+  })
+  markUnmarkAsFavorite(event);
+  openModal(event);
+}
+
+// if (event.target.id === ) {
+//   markUnmarkReadyToCook(event);
+//   // debugger
+//   removeRecipeCard(event);
+// }
+// // removeRecipeCard(event);
 
 function markUnmarkAsFavorite(event) {
   recipeBox.allRecipes.forEach(recipe => {
     if (event.target.id === `favorite-btn-${recipe.id}`) {
       updateRecipeBoolean(recipe, 'isFavorite');
+      // debugger
       toggleHeartImg(recipe);
     }
   })
@@ -115,36 +112,6 @@ function displayAllRecipes(recipes) {
   })
 }
 
-// function displaySavedRecipes(recipes) {
-//   recipes.forEach(recipe => {
-//     let recipeCard = createRecipes(recipe)
-//     recipeCardContainer.insertAdjacentHTML('afterbegin', recipeCard);
-//   })
-// }
-//
-// function highlightPageOnMenu(id) {
-//   let navButton = document.getElementById(id);
-//
-//   if (navButton.style.color === 'black') {
-//     navButton.style.color = '#d54215';
-//   } else {
-//     navButton.style.color = 'black';
-//   }
-// }
-
-//
-// function highlightPageOnMenu(eventId) {
-//   let navButton = document.getElementById(eventId);
-//
-//   const navButtons = ['nav1', 'nav2', 'nav3', 'nav4'];
-//   navButtons.forEach(id => {
-//     if (navId === eventId) {
-//       id.style.color = '#145b9c'
-//     } else {
-//       id.style.color = '#d54215'
-//   })
-// }
-
   function createRecipes(recipe) {
   let recipeCard = `<div class="recipe-card recipe-${recipe.id}" id="recipe-${recipe.id}">
     <div class="recipe-img-box">
@@ -152,7 +119,7 @@ function displayAllRecipes(recipes) {
     </div>
     <div class="recipe-action-btns flex-row">
       <button id="favorite-btn"><img src="../assets/heart-icon-${recipe.isFavorite}.png" id="favorite-btn-${recipe.id}" alt="favorite button"></button>
-      <button id="whats-cookin-btn"><img src="../assets/plus-icon-${recipe.readyToCook}.png" id="whats-cookin-btn-${recipe.id}" alt="save button"></button>
+      <button class="whats-cookin-btn" id="whats-cookin-btn"><img class="whats-cookin-btn" src="../assets/plus-icon-${recipe.readyToCook}.png" id="whats-cookin-btn-${recipe.id}" alt="save button"></button>
     </div>
     <h3>${recipe.name}</h3>
     <button class="show-recipe-btn-${recipe.id}" id="show-recipe-btn"><h3 class="show-recipe-btn-${recipe.id}">Show Recipe</h3></button>
@@ -201,107 +168,64 @@ function displayIngredients() {
   });
 }
 
+
 function showAllRecipes() {
   allRecipesContainer.classList.remove('hidden');
   searchContainer.classList.remove('hidden');
-  recipeCardContainer.innerHTML = '';
+  favoritesContainer.innerHTML = '';
   pantryContainer.innerHTML = '';
+  whatsCookinContainer.innerHTML = '';
   displayAllRecipes(recipeBox.allRecipes);
-  // displayAllRecipes(user.favoriteRecipes);
-  // displayAllRecipes(user.recipesToCook);
-  highlightPageOnMenu('nav1');
+  // highlightPageOnMenu('nav1');
 }
 
 function showFavorites() {
   allRecipesContainer.classList.add('hidden');
   searchContainer.classList.remove('hidden');
-  recipeCardContainer.innerHTML = '';
+  favoritesContainer.innerHTML = '';
   pantryContainer.innerHTML = '';
+  whatsCookinContainer.innerHTML = '';
+
   recipeBox.allRecipes.forEach(recipe => {
     if (recipe.isFavorite === true) {
-      displayRecipesInFavorites(recipe);
+      displaySavedRecipes(recipe, 'favoritesContainer');
     }
   })
 }
 
-function displayRecipesInFavorites(recipe) {
+function displaySavedRecipes(recipe, container) {
   let recipeCard = createRecipes(recipe)
-  recipeCardContainer.insertAdjacentHTML('afterbegin', recipeCard);
+  if (container === 'favoritesContainer') {
+    favoritesContainer.insertAdjacentHTML('afterbegin', recipeCard);
+  } else if (container === 'whatsCookinContainer') {
+    whatsCookinContainer.insertAdjacentHTML('afterbegin', recipeCard);
+  }
 }
 
+// function displaySavedRecipes(recipe) {
+//   let recipeCard = createRecipes(recipe)
+//   recipeCardContainer.insertAdjacentHTML('afterbegin', recipeCard);
+// }
+
 function showMyPantry() {
-  allRecipesContainer.classList.remove('hidden');
+  allRecipesContainer.classList.add('hidden');
   searchContainer.classList.remove('hidden');
-  recipeCardContainer.innerHTML = '';
+  favoritesContainer.innerHTML = '';
+  pantryContainer.innerHTML = '';
+  whatsCookinContainer.innerHTML = '';
   displayIngredients();
-  highlightPageOnMenu('nav3');
+  // highlightPageOnMenu('nav3');
 }
 
 function showWhatsCookin() {
+  allRecipesContainer.classList.add('hidden');
   searchContainer.classList.add('hidden');
-  recipeCardContainer.innerHTML = '';
+  favoritesContainer.innerHTML = '';
   pantryContainer.innerHTML = '';
-  displaySavedRecipes(user.recipesToCook);
-  highlightPageOnMenu('nav4');
-}
-
-// function addRecipeToFavorites(target) {
-//   recipeBox.allRecipes.forEach(recipe => {
-//     if (event.target.id === `favorite-btn-${recipe.id}`) {
-//       console.log(`added ${recipe.name} to favorites`)
-//       user.toggleRecipeStatus(user.favoriteRecipes, 'isFavorite', recipe);
-//     }
-//   })
-// }
-//
-// function addRecipeToWhatsCookin(target) {
-//   recipeBox.allRecipes.forEach(recipe => {
-//     if (event.target.id === `whats-cookin-btn-${recipe.id}`) {
-//       console.log(`added ${recipe.name} to whats cookin`)
-//       user.toggleRecipeStatus(user.recipesToCook, 'readyToCook', recipe);
-//     }
-//   })
-// }
-
-// -------------- NOTES -----------------
-// under user remove favorites arr and ready to cook array
-// use the booleans in recipe when displaying favorites and ready to cook
-
-//
-// function addRemoveFavorites(target) {
-//   let recipe = findRecipeFromEvent(event)
-//   recipeBox.allRecipes.forEach(recipe => {
-//
-//     if ((event.target.id === `favorite-btn-${recipe.id}`) && (recipe.isFavorite === false)) {
-//
-//       console.log(`added ${recipe.name} to favorites`)
-//       user.toggleRecipeStatus(user.favoriteRecipes, 'isFavorite', recipe);
-//       toggleHeartImg(recipe);
-//       debugger
-//     } else if ((event.target.id === `favorite-btn-${recipe.id}`) && (recipe.isFavorite === true)){
-//       console.log(`removed ${recipe.name} from favorites`)
-//       //needs to make isFavorite = false (This is done on line 23 of toggleRecipeStatus)
-//       //heart will need to be toggled on recipe in all recipes container
-//       toggleHeartImg(recipe);
-//       removeRecipeCard(recipe);
-//
-//       user.toggleRecipeStatus(user.favoriteRecipes, 'isFavorite', recipe);
-//       // removeRecipeCard(recipe);
-//       // recipeBox.allRecipes.push(recipe);
-//     }
-//   })
-// }
-
-function addRemoveWhatsCookin(target) {
+  whatsCookinContainer.innerHTML = '';
   recipeBox.allRecipes.forEach(recipe => {
-    if ((event.target.id === `whats-cookin-btn-${recipe.id}`) && (recipe.readyToCook === false)) {
-      console.log(`added ${recipe.name} to What's Cookin'`)
-      user.toggleRecipeStatus(user.readyToCook, 'readyToCook', recipe);
-      togglePlusImg(recipe);
-    } else if ((event.target.id === `whats-cookin-btn-${recipe.id}`) && (recipe.readyToCook === true)) {
-      user.toggleRecipeStatus(user.readyToCook, 'readyToCook', recipe);
-      removeRecipeCard(recipe);
-      // recipeBox.allRecipes.push(recipe);
+    if (recipe.readyToCook === true) {
+      displaySavedRecipes(recipe, 'whatsCookinContainer');
     }
   })
 }
@@ -309,10 +233,10 @@ function addRemoveWhatsCookin(target) {
 function removeRecipeCard(event) {
   recipeBox.allRecipes.forEach(recipe => {
     if (event.target.id === `favorite-btn-${recipe.id}`) {
-      let toRemove = document.querySelector(`.recipes-container .recipe-${recipe.id}`);
+      let toRemove = document.querySelector(`.favorites-container .recipe-${recipe.id}`);
       toRemove.remove(event.target.id === `favorite-btn-${recipe.id}`);
     } else if (event.target.id === `whats-cookin-btn-${recipe.id}`) {
-      let toRemove = document.querySelector(`.recipes-container .recipe-${recipe.id}`);
+      let toRemove = document.querySelector(`.whats-cookin-container .recipe-${recipe.id}`);
       toRemove.remove(event.target.id === `whats-cookin-btn-${recipe.id}`);
     }
   })
@@ -328,9 +252,9 @@ function toggleHeartImg(recipe) {
 
 function togglePlusImg(recipe) {
   if (recipe.readyToCook === true) {
-    document.querySelector(`#whats-cookin-btn-${recipe.id}`).src = `../assets/plus-icon-${recipe.readyToCook}.png`
+    document.querySelector(`#whats-cookin-btn-${recipe.id}`).src = `../assets/plus-icon-true.png`
   } else {
-    document.querySelector(`#whats-cookin-btn-${recipe.id}`).src = `../assets/plus-icon-${recipe.readyToCook}.png`
+    document.querySelector(`#whats-cookin-btn-${recipe.id}`).src = `../assets/plus-icon-false.png`
   }
 }
 
@@ -343,7 +267,7 @@ function addToWhatsCookin(target) {
   })
 }
 
-function openModel() {
+function openModal() {
   recipeBox.allRecipes.forEach(recipe => {
     if (event.target.className === `show-recipe-btn-${recipe.id}`) {
       modal = document.querySelector('.modal');

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -9,6 +9,7 @@ const instructionsBtn = document.getElementById('preview-btn');
 const closeModalBtn = document.querySelector('.close');
 const searchContainer = document.querySelector('#search-container');
 const pantryContainer = document.querySelector('.pantry-container');
+const allRecipesContainer = document.querySelector('.all-recipes-container');
 
 let user = new User(usersData[0], ingredientsData);
 let recipeBox = new RecipeBox(recipeData, ingredientsData);
@@ -22,93 +23,167 @@ allRecipesNav.addEventListener('click', showAllRecipes);
 myPantryNav.addEventListener('click', showMyPantry);
 whatsCookinNav.addEventListener('click', showWhatsCookin);
 
+allRecipesContainer.addEventListener('click', () => {
+  determineClickOnAllRecipes(event);
+});
+
 recipeCardContainer.addEventListener('click', () => {
   determineClick(event);
 });
+// ON HOMESCREEN
+//when heart is clicked
+// need to be able to mark as favorite/ unmark as favorite
+  // need eventlisteners for heart icons (through event bubbling)
+  // this should change boolean value, change heart icon (change heart icon)
+
+  //when plus is clicked
+  // need to be able to mark as readyToCook / unmark as readyToCook
+   // need eventlisteners for plus (through event bubbling)
+   // this should change boolean value of readyToCook, change plus icon
+// ----------------------
+// when favorites page is clicked on,
+  // parse all recipes,
+    // if isFavorites is true,
+      // create recipe card and display
+      // need eventlisteners for plus (through event bubbling)
+  // when heart is deselected,
+     // boolean value needs to change, toggle heart graphic, and splice html.
+
+//WHATS COOKIN
+//when what's Cookin page is clicked on,
+  // parse all recipes
+      // if what's cookin is true
+      // create recipe card and display
+      // need eventlisteners for plus (through event bubbling)
+// when plus icon is deselected (aka minus is clicked),
+  // boolean value needs to change, toggle plus graphic, and splice html.
+
+// function determineClick(event) {
+//   addRemoveFavorites(event);
+//   addToWhatsCookin(event);
+//   openModel(event);
+// }
+function determineClickOnAllRecipes(event) {
+  markUnmarkAsFavorite(event);
+  markUnmarkReadyToCook(event);
+}
 
 function determineClick(event) {
-  addRemoveFavorites(event.target);
-  addToWhatsCookin(event.target);
+  markUnmarkAsFavorite(event);
+  markUnmarkReadyToCook(event);
+  removeRecipeCard(event);
   openModel(event);
 }
 
-function loadPage() {
-  // recipeData.forEach(recipe => {
-  //   recipeBox.allRecipes.push(new Recipe(recipe));
-  // })
-  // displayRecipes(allRecipes);
+function markUnmarkAsFavorite(event) {
+  recipeBox.allRecipes.forEach(recipe => {
+    if (event.target.id === `favorite-btn-${recipe.id}`) {
+      updateRecipeBoolean(recipe, 'isFavorite');
+      toggleHeartImg(recipe);
+    }
+  })
+}
 
+function markUnmarkReadyToCook(event) {
+  recipeBox.allRecipes.forEach(recipe => {
+    if (event.target.id === `whats-cookin-btn-${recipe.id}`) {
+      updateRecipeBoolean(recipe, 'readyToCook');
+      togglePlusImg(recipe);
+    }
+  })
+}
+
+function updateRecipeBoolean(recipe, property) {
+  recipe[property] = !recipe[property];
+}
+
+function loadPage() {
   recipeBox.makeRecipes()
   user.pantry.makeIngredients();
   user.pantry.ingredients.forEach(ingredient => {
     ingredient.updateIngredientData(user.pantry.ingredients, 'amount');
   })
-  displayRecipes(recipeBox.allRecipes);
+  displayAllRecipes(recipeBox.allRecipes);
 }
 
-function highlightPageOnMenu(id) {
-  let navButton = document.getElementById(id);
-
-  if (navButton.style.color === 'black') {
-    navButton.style.color = '#d54215';
-  } else {
-    navButton.style.color = 'black';
-  }
+function displayAllRecipes(recipes) {
+  recipes.forEach(recipe => {
+    if (!user.favoriteRecipes.includes(recipe) && !user.recipesToCook.includes(recipe)) {
+      let recipeCard = createRecipes(recipe)
+      allRecipesContainer.insertAdjacentHTML('afterbegin', recipeCard);
+    }
+  })
 }
 
+// function displaySavedRecipes(recipes) {
+//   recipes.forEach(recipe => {
+//     let recipeCard = createRecipes(recipe)
+//     recipeCardContainer.insertAdjacentHTML('afterbegin', recipeCard);
+//   })
+// }
+//
+// function highlightPageOnMenu(id) {
+//   let navButton = document.getElementById(id);
+//
+//   if (navButton.style.color === 'black') {
+//     navButton.style.color = '#d54215';
+//   } else {
+//     navButton.style.color = 'black';
+//   }
+// }
 
+//
 // function highlightPageOnMenu(eventId) {
 //   let navButton = document.getElementById(eventId);
+//
 //   const navButtons = ['nav1', 'nav2', 'nav3', 'nav4'];
 //   navButtons.forEach(id => {
 //     if (navId === eventId) {
-//       [id].style.color = '#145b9c'
+//       id.style.color = '#145b9c'
 //     } else {
-//       [id].style.color = '#d54215'
+//       id.style.color = '#d54215'
 //   })
 // }
 
-function displayRecipes(recipes) {
-  recipes.forEach(recipe => {
-    let recipeCard = `<div class="recipe-card recipe-${recipe.id}">
-      <div class="recipe-img-box">
-        <img src=${recipe.image} alt="recipe image" class="recipe-display-img">
-      </div>
-      <div class="recipe-action-btns flex-row">
-        <button id="favorite-btn"><img src="../assets/heart-icon-${recipe.isFavorite}.png" id="favorite-btn-${recipe.id}" alt="favorite button"></button>
-        <button id="whats-cookin-btn"><img src="../assets/plus-icon-${recipe.readyToCook}.png" id="whats-cookin-btn-${recipe.id}" alt="save button"></button>
-      </div>
-      <h3>${recipe.name}</h3>
-      <button class="show-recipe-btn-${recipe.id}" id="show-recipe-btn"><h3 class="show-recipe-btn-${recipe.id}">Show Recipe</h3></button>
-        <div class="modal">
-          <div class="modal-content flex-column">
-            <div class="modal-header">
-              <div>
-                <img src=${recipe.image} alt="recipe image" class="modal-banner">
-              </div>
+  function createRecipes(recipe) {
+  let recipeCard = `<div class="recipe-card recipe-${recipe.id}" id="recipe-${recipe.id}">
+    <div class="recipe-img-box">
+      <img src=${recipe.image} alt="recipe image" class="recipe-display-img">
+    </div>
+    <div class="recipe-action-btns flex-row">
+      <button id="favorite-btn"><img src="../assets/heart-icon-${recipe.isFavorite}.png" id="favorite-btn-${recipe.id}" alt="favorite button"></button>
+      <button id="whats-cookin-btn"><img src="../assets/plus-icon-${recipe.readyToCook}.png" id="whats-cookin-btn-${recipe.id}" alt="save button"></button>
+    </div>
+    <h3>${recipe.name}</h3>
+    <button class="show-recipe-btn-${recipe.id}" id="show-recipe-btn"><h3 class="show-recipe-btn-${recipe.id}">Show Recipe</h3></button>
+      <div class="modal">
+        <div class="modal-content flex-column">
+          <div class="modal-header">
+            <div>
+              <img src=${recipe.image} alt="recipe image" class="modal-banner">
             </div>
-            <div class="modal-body flex-column">
-            <div class="modal-header-text flex-row">
-              <h1>${recipe.name}</h1>
+          </div>
+          <div class="modal-body flex-column">
+          <div class="modal-header-text flex-row">
+            <h1>${recipe.name}</h1>
+          </div>
+            <div class="flex-row">
+            <div class="card-effect"
+              <h2>Ingredients</h2>
+              <p class="ingredients-display">${recipe.makeIngredients()}</p>
+              <p><b>Total Cost of Ingredients</b></p>
+              <p class="ingredients-display">${recipe.calculateCost(ingredientsData)}</p>
             </div>
-              <div class="flex-row">
               <div class="card-effect"
-                <h2>Ingredients</h2>
-                <p class="ingredients-display">${recipe.makeIngredients(ingredientsData)}</p>
-                <p><b>Total Cost of Ingredients</b></p>
-                <p class="ingredients-display">${recipe.calculateCost(ingredientsData)}</p>
-              </div>
-                <div class="card-effect"
-                  <h2>How To Cook This</h2>
-                  <p>${recipe.getInstructions()}<p>
-                </div>
+                <h2>How To Cook This</h2>
+                <p>${recipe.getInstructions()}<p>
               </div>
             </div>
-           </div>
+          </div>
          </div>
-      </div>`
-      return recipeCardContainer.insertAdjacentHTML('afterbegin', recipeCard);
-    });
+       </div>
+    </div>`
+    return recipeCard
   }
 
 function displayIngredients() {
@@ -127,22 +202,35 @@ function displayIngredients() {
 }
 
 function showAllRecipes() {
+  allRecipesContainer.classList.remove('hidden');
   searchContainer.classList.remove('hidden');
   recipeCardContainer.innerHTML = '';
   pantryContainer.innerHTML = '';
-  displayRecipes(recipeBox.allRecipes);
+  displayAllRecipes(recipeBox.allRecipes);
+  // displayAllRecipes(user.favoriteRecipes);
+  // displayAllRecipes(user.recipesToCook);
   highlightPageOnMenu('nav1');
 }
 
 function showFavorites() {
+  allRecipesContainer.classList.add('hidden');
   searchContainer.classList.remove('hidden');
   recipeCardContainer.innerHTML = '';
   pantryContainer.innerHTML = '';
-  displayRecipes(user.favoriteRecipes);
-  highlightPageOnMenu('nav2');
+  recipeBox.allRecipes.forEach(recipe => {
+    if (recipe.isFavorite === true) {
+      displayRecipesInFavorites(recipe);
+    }
+  })
+}
+
+function displayRecipesInFavorites(recipe) {
+  let recipeCard = createRecipes(recipe)
+  recipeCardContainer.insertAdjacentHTML('afterbegin', recipeCard);
 }
 
 function showMyPantry() {
+  allRecipesContainer.classList.remove('hidden');
   searchContainer.classList.remove('hidden');
   recipeCardContainer.innerHTML = '';
   displayIngredients();
@@ -153,7 +241,7 @@ function showWhatsCookin() {
   searchContainer.classList.add('hidden');
   recipeCardContainer.innerHTML = '';
   pantryContainer.innerHTML = '';
-  displayRecipes(user.recipesToCook);
+  displaySavedRecipes(user.recipesToCook);
   highlightPageOnMenu('nav4');
 }
 
@@ -175,19 +263,34 @@ function showWhatsCookin() {
 //   })
 // }
 
-function addRemoveFavorites(target) {
-  recipeBox.allRecipes.forEach(recipe => {
-    if ((event.target.id === `favorite-btn-${recipe.id}`) && (recipe.isFavorite === false)) {
-      console.log(`added ${recipe.name} to favorites`)
-      user.toggleRecipeStatus(user.favoriteRecipes, 'isFavorite', recipe);
-      toggleHeartImg(recipe);
-    } else if ((event.target.id === `favorite-btn-${recipe.id}`) && (recipe.isFavorite === true)) {
-      user.toggleRecipeStatus(user.favoriteRecipes, 'isFavorite', recipe);
-      removeRecipeCard(recipe);
-      recipeBox.allRecipes.push(recipe);
-    }
-  })
-}
+// -------------- NOTES -----------------
+// under user remove favorites arr and ready to cook array
+// use the booleans in recipe when displaying favorites and ready to cook
+
+//
+// function addRemoveFavorites(target) {
+//   let recipe = findRecipeFromEvent(event)
+//   recipeBox.allRecipes.forEach(recipe => {
+//
+//     if ((event.target.id === `favorite-btn-${recipe.id}`) && (recipe.isFavorite === false)) {
+//
+//       console.log(`added ${recipe.name} to favorites`)
+//       user.toggleRecipeStatus(user.favoriteRecipes, 'isFavorite', recipe);
+//       toggleHeartImg(recipe);
+//       debugger
+//     } else if ((event.target.id === `favorite-btn-${recipe.id}`) && (recipe.isFavorite === true)){
+//       console.log(`removed ${recipe.name} from favorites`)
+//       //needs to make isFavorite = false (This is done on line 23 of toggleRecipeStatus)
+//       //heart will need to be toggled on recipe in all recipes container
+//       toggleHeartImg(recipe);
+//       removeRecipeCard(recipe);
+//
+//       user.toggleRecipeStatus(user.favoriteRecipes, 'isFavorite', recipe);
+//       // removeRecipeCard(recipe);
+//       // recipeBox.allRecipes.push(recipe);
+//     }
+//   })
+// }
 
 function addRemoveWhatsCookin(target) {
   recipeBox.allRecipes.forEach(recipe => {
@@ -198,14 +301,21 @@ function addRemoveWhatsCookin(target) {
     } else if ((event.target.id === `whats-cookin-btn-${recipe.id}`) && (recipe.readyToCook === true)) {
       user.toggleRecipeStatus(user.readyToCook, 'readyToCook', recipe);
       removeRecipeCard(recipe);
-      recipeBox.allRecipes.push(recipe);
+      // recipeBox.allRecipes.push(recipe);
     }
   })
 }
 
-function removeRecipeCard(recipe) {
-  let toRemove = document.querySelector(`.recipe-${recipe.id}`)
-  toRemove.remove();
+function removeRecipeCard(event) {
+  recipeBox.allRecipes.forEach(recipe => {
+    if (event.target.id === `favorite-btn-${recipe.id}`) {
+      let toRemove = document.querySelector(`.recipes-container .recipe-${recipe.id}`);
+      toRemove.remove(event.target.id === `favorite-btn-${recipe.id}`);
+    } else if (event.target.id === `whats-cookin-btn-${recipe.id}`) {
+      let toRemove = document.querySelector(`.recipes-container .recipe-${recipe.id}`);
+      toRemove.remove(event.target.id === `whats-cookin-btn-${recipe.id}`);
+    }
+  })
 }
 
 function toggleHeartImg(recipe) {


### PR DESCRIPTION
## What's this PR do?
- Complete refactor of how we manage My Favorites recipes and recipes in What's Cookin'. Added different containers to hold the recipe cards under each as well. This helps avoid recipes duplicating.

## Where should the reviewer start?
- Start by reviewing main.js

## How should this be manually tested?
- Test by opening the page and saving recipes to favorites and what's cookin. Notice they don't duplicate.

## Any background context you want to provide?
- Still working on being able to remove `favorite` icon from a recipe in What's Cookin' and vice versa. Status does change. Removing an element from the category user is under, does work though. For example, if user is in What's Cookin' and tries to unfavorite a recipe, the status change but the heart icon stays red.